### PR TITLE
feat: documentação swagger para backend

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@nestjs/common": "^11.0.1",
         "@nestjs/core": "^11.0.1",
         "@nestjs/platform-express": "^11.0.1",
+        "@nestjs/swagger": "^11.2.0",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1"
       },
@@ -1923,6 +1924,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/@microsoft/tsdoc": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.15.1.tgz",
+      "integrity": "sha512-4aErSrCR/On/e5G2hDP0wjooqDdauzEbIq8hIkIe5pXV0rtWJZvdCEKL0ykZxex+IxIwBp0eGeV48hQN07dXtw==",
+      "license": "MIT"
+    },
     "node_modules/@napi-rs/nice": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@napi-rs/nice/-/nice-1.0.4.tgz",
@@ -2515,6 +2522,26 @@
         }
       }
     },
+    "node_modules/@nestjs/mapped-types": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.1.0.tgz",
+      "integrity": "sha512-W+n+rM69XsFdwORF11UqJahn4J3xi4g/ZEOlJNL6KoW5ygWSmBB2p0S2BZ4FQeS/NDH72e6xIcu35SfJnE8bXw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "class-transformer": "^0.4.0 || ^0.5.0",
+        "class-validator": "^0.13.0 || ^0.14.0",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@nestjs/platform-express": {
       "version": "11.1.3",
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.1.3.tgz",
@@ -2634,6 +2661,39 @@
         "tslib": "^2.1.0"
       }
     },
+    "node_modules/@nestjs/swagger": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-11.2.0.tgz",
+      "integrity": "sha512-5wolt8GmpNcrQv34tIPUtPoV1EeFbCetm40Ij3+M0FNNnf2RJ3FyWfuQvI8SBlcJyfaounYVTKzKHreFXsUyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/tsdoc": "0.15.1",
+        "@nestjs/mapped-types": "2.1.0",
+        "js-yaml": "4.1.0",
+        "lodash": "4.17.21",
+        "path-to-regexp": "8.2.0",
+        "swagger-ui-dist": "5.21.0"
+      },
+      "peerDependencies": {
+        "@fastify/static": "^8.0.0",
+        "@nestjs/common": "^11.0.1",
+        "@nestjs/core": "^11.0.1",
+        "class-transformer": "*",
+        "class-validator": "*",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@fastify/static": {
+          "optional": true
+        },
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@nestjs/testing": {
       "version": "11.1.3",
       "resolved": "https://registry.npmjs.org/@nestjs/testing/-/testing-11.1.3.tgz",
@@ -2751,6 +2811,13 @@
       "funding": {
         "url": "https://opencollective.com/pkgr"
       }
+    },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@sec-ant/readable-stream": {
       "version": "0.4.1",
@@ -4720,7 +4787,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/array-timsort": {
@@ -8300,7 +8366,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -8493,7 +8558,6 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.memoize": {
@@ -10546,6 +10610,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.21.0.tgz",
+      "integrity": "sha512-E0K3AB6HvQd8yQNSMR7eE5bk+323AUxjtCz/4ZNKiahOlPhPJxqn3UPIGs00cyY/dhrTDJ61L7C/a8u6zhGrZg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
       }
     },
     "node_modules/symbol-observable": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@nestjs/common": "^11.0.1",
     "@nestjs/core": "^11.0.1",
     "@nestjs/platform-express": "^11.0.1",
+    "@nestjs/swagger": "^11.2.0",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1"
   },

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,21 @@
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+
+  // Configuração do Swagger
+  const config = new DocumentBuilder()
+    .setTitle('Um Sushi API')
+    .setDescription('API para o cardápio e pedidos do Um Sushi')
+    .setVersion('1.0')
+    .build();
+
+  const document = SwaggerModule.createDocument(app, config);
+  SwaggerModule.setup('api', app, document); 
+
+  await app.listen(3000);
+}
+bootstrap();

--- a/src/menu/dto/create-order.dto.ts
+++ b/src/menu/dto/create-order.dto.ts
@@ -1,6 +1,23 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class OrderItem {
+  @ApiProperty({ example: 1, description: 'ID do produto' })
+  productId!: number;
+
+  @ApiProperty({ example: 2, description: 'Quantidade do produto' })
+  quantity!: number;
+}
+
 export class CreateOrderDto {
-  items!: { productId: number; quantity: number }[];
+  @ApiProperty({ example: 'Gil do Vigor', description: 'Nome do cliente' })
   customerName!: string;
+
+  @ApiProperty({ example: '999999999', description: 'Telefone do cliente' })
   customerPhone!: string;
-  address?: string;
+
+  @ApiProperty({ example: 'Rua das Flores, 123', description: 'Endereço para entrega' })
+  address!: string;
+
+  @ApiProperty({ type: [OrderItem], description: 'Lista de itens do pedido' })
+  items!: OrderItem[];
 }

--- a/src/menu/main.ts
+++ b/src/menu/main.ts
@@ -1,9 +1,0 @@
-import { NestFactory } from '@nestjs/core';
-import { AppModule } from '../app.module';
-
-
-async function bootstrap() {
-  const app = await NestFactory.create(AppModule);
-  await app.listen(3000);
-}
-bootstrap();

--- a/src/menu/menu.controller.ts
+++ b/src/menu/menu.controller.ts
@@ -1,18 +1,24 @@
 import { Controller, Get, Post, Body } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { MenuService } from './menu.service';
 import { CreateOrderDto } from './dto/create-order.dto';
 
+@ApiTags('Menu')
 @Controller('menu')
 export class MenuController {
   constructor(private readonly menuService: MenuService) {}
 
   @Get()
+  @ApiOperation({ summary: 'Retorna os itens do cardápio' })
+  @ApiResponse({ status: 200, description: 'Lista de produtos retornada com sucesso.' })
   getMenu() {
     return this.menuService.getMenuItems();
   }
 
   @Post('order')
-  createOrder(@Body() orderDto: CreateOrderDto) {
-    return this.menuService.createOrder(orderDto);
+  @ApiOperation({ summary: 'Cria um novo pedido' })
+  @ApiResponse({ status: 201, description: 'Pedido criado com sucesso.' })
+  createOrder(@Body() order: CreateOrderDto) {
+    return this.menuService.createOrder(order);
   }
 }


### PR DESCRIPTION
Adição do swagger para gerar uma documentação interativa que inclui informações detalhadas sobre os endpoints, os métodos HTTP suportados, os parâmetros de requisição e resposta, além de exemplos de uso.